### PR TITLE
Add deeplink to be able to connect and detect subwallet mobile app

### DIFF
--- a/sdk/packages/selector-polkadot/src/adapter.ts
+++ b/sdk/packages/selector-polkadot/src/adapter.ts
@@ -171,6 +171,15 @@ export class NightlyConnectAdapter implements Injected {
 
     const [app, metadataWallets] = await NightlyConnectAdapter.initApp(appInitData)
 
+    // Todo: Remove this after update metadata for SubWallet
+    metadataWallets.forEach((walletMetadata) => {
+      if (walletMetadata.slug === 'subwallet-js') {
+        walletMetadata.walletType = 'hybrid';
+        // SubWallet also has a native link `subwallet://` but the universal link delivers better UX in case the mobile app is not installed
+        walletMetadata.mobile = { native: null , universal: 'https://mobile.subwallet.app' };
+      }
+    })
+
     adapter._app = app
     adapter._metadataWallets = metadataWallets
 
@@ -369,6 +378,15 @@ export class NightlyConnectAdapter implements Injected {
       })
 
       this._chosenMobileWalletName = walletName
+
+      // Connect with SubWallet Mobile App via universal link
+      if(typeof window !== 'undefined' && wallet.slug === 'subwallet-js'){
+        const url = `${wallet.deeplink.universal}/browser?url=${encodeURIComponent(window.location.toString())}`;
+
+        window.open(url, '_blank', 'noreferrer noopener');
+
+        return;
+      }
 
       triggerConnect(
         wallet.deeplink.universal,


### PR DESCRIPTION
- [x]  Modify the API of Connect Nightly when getting wallet metadata, including modifying the walletType, and for mobile, it needs to have a deeplink 
`{
   "walletType": "hybrid",
    "mobile": { 
                     native: null ,
                     universal: 'https://mobile.subwallet.app' 
                    },
    "desktop": null,
 }`
API : https://nc2.nightly.app/get_wallets_metadata
- [x]  Create a connection according to the correct deeplink standard to connect with the mobile subwallet.